### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,10 @@ fn main() {
     println!("Sun altitude                   = {:.3} °", sun_max_altitude); // expected 46.892 deg
     println!("Atmospheric refraction         =  {:.3} °", atmosfer_refract); // expected 0.015 deg
     println!("Refraction corrected elevation = {:.3} °", correct_height); // expected 46.91 deg
-    println!("Day length             = {:.?}", daylen);
-    println!("Sunrise time           = {:.?} ", rise_time);
-    println!("Noon time              = {:.?}", noon_time);
-    println!("Sunset time            = {:.?}", set_time);
+    println!("Day length             = {:?}", daylen);
+    println!("Sunrise time           = {:?} ", rise_time);
+    println!("Noon time              = {:?}", noon_time);
+    println!("Sunset time            = {:?}", set_time);
   } // End of main
 
     fn get_hrmn(dayfract: f64) -> NaiveTime {


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.